### PR TITLE
Removing space for QCMD path (bug)

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -30,7 +30,7 @@ export KDBPCAPS=${TORQAPPHOME}/pcaps
 # set rlwrap and qcon paths for use in torq.sh qcon flag functions
 export RLWRAP="rlwrap"
 export QCON="qcon"
-export QCMD ="q" #set qcmd path
+export QCMD="q" #set qcmd path
 
 # set the application specific configuration directory
 export KDBAPPCONFIG=${TORQAPPHOME}/appconfig


### PR DESCRIPTION
Pull Request Label
Bug

Team Member(s) who solved this issue
Jonny Crawford

Summary
Removed space in QCMD path which caused a error when running the TorQ stack

Details
Removed space before the "=" to fix this issue

